### PR TITLE
Fix for typo

### DIFF
--- a/smppclient.class.php
+++ b/smppclient.class.php
@@ -705,15 +705,15 @@ class SmppClient
 		extract(unpack("Ncommand_id/Ncommand_status/Nsequence_number", $bufHeaders));
 		
 		// Read PDU body
-		if($length-16>0){
-			$body=$this->transport->readAll($length-16);
+		if($bufLength-16>0){
+			$body=$this->transport->readAll($bufLength-16);
 			if(!$body) throw new RuntimeException('Could not read PDU body');
 		} else {
 			$body=null;
 		}
 		
 		if($this->debug) {
-			call_user_func($this->debugHandler, "Read PDU         : $length bytes");
+			call_user_func($this->debugHandler, "Read PDU         : $bufLength bytes");
 			call_user_func($this->debugHandler, ' '.chunk_split(bin2hex($bufLength.$bufHeaders.$body),2," "));
 			call_user_func($this->debugHandler, " command id      : 0x".dechex($command_id));
 			call_user_func($this->debugHandler, " command status  : 0x".dechex($command_status)." ".SMPP::getStatusMessage($command_status));


### PR DESCRIPTION
Hey,

I couldn't get this working, getting an error after binding. After some investigation, it seems there was a typo. The variable $length was used where $bufLength should have been used ($length wasn't declared at all).

I've updated the code in my repo.

Thanks

Colm
