### PR TITLE
Added to regex a white space in "stat" part for some gateways

### DIFF
--- a/smppclient.class.php
+++ b/smppclient.class.php
@@ -1061,7 +1061,7 @@ class SmppDeliveryReceipt extends SmppSms
 	 */
 	public function parseDeliveryReceipt()
 	{
-		$numMatches = preg_match('/^id:([^ ]+) sub:(\d{1,3}) dlvrd:(\d{3}) submit date:(\d{10,12}) done date:(\d{10,12}) stat:([A-Z]{7}) err:(\d{2,3}) text:(.*)$/si', $this->message, $matches);
+		$numMatches = preg_match('/^id:([^ ]+) sub:(\d{1,3}) dlvrd:(\d{3}) submit date:(\d{10,12}) done date:(\d{10,12}) stat:([A-Z ]{7}) err:(\d{2,3}) text:(.*)$/si', $this->message, $matches);
 		if ($numMatches == 0) {
 			throw new InvalidArgumentException('Could not parse delivery receipt: '.$this->message."\n".bin2hex($this->body));	
 		}


### PR DESCRIPTION
Some suppliers fill the stat with white spaces. For example:
- DELIVRD: 7 chars / 0 white spaces
- ACKED   : 5 chars / 2 white spaces

With this patch all is parsed without problems in any case.
