### PR TITLE
Fix CSMS not working with CSMS_16BIT_TAGS

### DIFF
--- a/smppclient.class.php
+++ b/smppclient.class.php
@@ -300,7 +300,7 @@ class SmppClient
 		// Figure out if we need to do CSMS, since it will affect our PDU
 		if ($msg_length > $singleSmsOctetLimit) {
 			$doCsms = true;
-			if (!self::$csms_method != SmppClient::CSMS_PAYLOAD) {
+			if (self::$csms_method != SmppClient::CSMS_PAYLOAD) {
 				$parts = $this->splitMessageString($message, $csmsSplit, $dataCoding);
 				$short_message = reset($parts);
 				$csmsReference = $this->getCsmsReference();


### PR DESCRIPTION
Sending multipart SMS with the default csms_method CSMS_16BIT_TAGS will never work because of the way this comparison is set up.
`SmppClient::CSMS_PAYLOAD` is 1
`SmppClient::CSMS_16BIT_TAGS` is 0

Therefore `(!SmppClient::CSMS_16BIT_TAGS != SmppClient::CSMS_PAYLOAD)` will be false.

As far as I can see the only case where we don't need $parts later on is when `self::$csms_method == CSMS_PAYLOAD`.
