### PR TITLE
Increment sequence_number after failure

### DIFF
--- a/smppclient.class.php
+++ b/smppclient.class.php
@@ -619,11 +619,11 @@ class SmppClient
 		$response=$this->readPDU_resp($this->sequence_number, $pdu->id);
 		if ($response === false) throw new SmppException('Failed to read reply to command: 0x'.dechex($id));
 		
-		if ($response->status != SMPP::ESME_ROK) throw new SmppException(SMPP::getStatusMessage($response->status), $response->status);
-		
 		$this->sequence_number++;
 		
-		// Reached max sequence number, spec does not state what happens now, so we re-connect
+		if ($response->status != SMPP::ESME_ROK) throw new SmppException(SMPP::getStatusMessage($response->status), $response->status);
+		
+				// Reached max sequence number, spec does not state what happens now, so we re-connect
 		if ($this->sequence_number >= 0x7FFFFFFF) {
 			$this->reconnect();
 		}


### PR DESCRIPTION
After an sendSMS submission returns a legitimate exception (i.e. `$response->status != SMPP::ESME_ROK`), the sequence_number isn't incremented. This casues the SMSC to fail all subsequent messages as the sequence number is the same as the original failed submission.

The incrementing of sequence_number on line 624 of smppclient.class.php should be moved prior to the exception on line 622.

If the class supported resubmission attempts this sequence_number should probably not be incremented however as this feature isn't supported, we should just increment it and move on.