### PR TITLE
Added new params to override default plugin values

### DIFF
--- a/smppclient.class.php
+++ b/smppclient.class.php
@@ -783,6 +783,25 @@ class SmppClient
 		}
 		return $tag;
 	}
+
+	/* Akshath 
+	 * Added new functions to override default plugin params
+	 */
+	public function setSystemType($system_type) {
+		self::$system_type = $system_type;
+	}
+	
+	public function setAddressTON($ton) {
+		self::$addr_ton = $ton;
+	}
+	
+	public function setAddressNPI($npi) {
+		self::$addr_npi = $npi;
+	}
+	
+	public function setAddressRange($address_range) {
+		self::$address_range = $address_range;
+	}
 	
 }
 


### PR DESCRIPTION
TON, NPI, Address Range and System_Type was set to default values under SmppClient class. But some providers need this values to be altered. So added APIs to reset default values.
